### PR TITLE
Updated how character streams convert characters

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -5,13 +5,13 @@
 int main()
 {
 	z::system::console console;
-	// z::file::outputStream out("out.txt", z::utf16);
-	z::file::inputStream in("out.txt");
+	z::file::outputStream out("out.txt", z::utf32, true);
+	// z::file::inputStream in("out.txt");
 
-	zpath(in.good() ? "good" : "bad").writeln(console);
+	// zpath(in.good() ? "good" : "bad").writeln(console);
 
-	z::core::string<z::utf16> str;
-	str.read(in);
+	z::core::string<z::utf8> str = "test";
+	// str.read(in);
 	// switch (in.format())
 	// {
 	// 	case z::ascii:
@@ -34,7 +34,7 @@ int main()
 	// 		str = "unknown";
 	// }
 
-	str.writeln(console);
+	str.writeln(out);
 	// z::core::string<z::utf16>("hello, this is a test.").writeln(out);
 
 	return 0;

--- a/main.cpp
+++ b/main.cpp
@@ -5,19 +5,37 @@
 int main()
 {
 	z::system::console console;
+	// z::file::outputStream out("out.txt", z::utf16);
+	z::file::inputStream in("out.txt");
 
-	z::core::string<z::utf8> str = "this is a memory stream test!";
-	z::core::memoryStream stream (str.cstring(), 29);
+	zpath(in.good() ? "good" : "bad").writeln(console);
 
-	z::core::string<z::utf8> repl = "prebus";
-	stream.seek(10);
-
-	// std::cout << (void*)buffer << std::endl;
-
-	// stream.put('G');
-	repl.write(stream);
+	z::core::string<z::utf16> str;
+	str.read(in);
+	// switch (in.format())
+	// {
+	// 	case z::ascii:
+	// 		str = "ascii";
+	// 	break;
+	//
+	// 	case z::utf8:
+	// 		str = "utf8";
+	// 	break;
+	//
+	// 	case z::utf16:
+	// 		str = "utf16";
+	// 	break;
+	//
+	// 	case z::utf32:
+	// 		str = "utf32";
+	// 	break;
+	//
+	// 	default:
+	// 		str = "unknown";
+	// }
 
 	str.writeln(console);
+	// z::core::string<z::utf16>("hello, this is a test.").writeln(out);
 
 	return 0;
 }

--- a/z/core/binaryStream.cpp
+++ b/z/core/binaryStream.cpp
@@ -138,7 +138,10 @@ namespace z
 
 		encoding binaryStream::format()
 		{
-			if (this->empty()) return ascii;
+			if (initialized) return streamFormat;
+			initialized = true;
+
+			if (this->empty()) return streamFormat = ascii;
 
 			size_t read_max = (32 > data.length()) ? data.length() : 32;
 
@@ -152,7 +155,7 @@ namespace z
 				if (found_nulls || !data[i])
 				{
 					found_nulls = true;
-					if (contig_nulls >= 2) return utf32;
+					if (contig_nulls >= 2) return streamFormat = utf32;
 
 					contig_nulls++;
 				}
@@ -167,9 +170,18 @@ namespace z
 				}
 			}
 
-			if (found_nulls) return utf16;
+			if (found_nulls) return streamFormat = utf16;
 
-			return can_utf8 ? utf8 : ascii;
+			return streamFormat = (can_utf8 ? utf8 : ascii);
+		}
+
+		void binaryStream::setFormat(encoding enc, bool force)
+		{
+			if (!initialized || force)
+			{
+				streamFormat = enc;
+				initialized = true;
+			}
 		}
 
 		void binaryStream::flush() {}

--- a/z/core/binaryStream.h
+++ b/z/core/binaryStream.h
@@ -17,6 +17,8 @@ namespace z
 		private:
 			array<uint8_t> data;
 			size_t streamIndex;
+			encoding streamFormat;
+			bool initialized;
 
 		public:
 			binaryStream();
@@ -38,6 +40,7 @@ namespace z
  			size_t end();
 
 			encoding format();
+			void setFormat(encoding enc, bool force = false);
 
 			void flush();
 		};

--- a/z/core/memoryStream.cpp
+++ b/z/core/memoryStream.cpp
@@ -139,7 +139,10 @@ namespace z
 
 		encoding memoryStream::format()
 		{
-			if (this->empty()) return ascii;
+			if (initialized) return streamFormat;
+			initialized = true;
+
+			if (this->empty()) return streamFormat = ascii;
 
 			size_t read_max = (32 > dataSize) ? dataSize : 32;
 
@@ -153,7 +156,7 @@ namespace z
 				if (found_nulls || !data[i])
 				{
 					found_nulls = true;
-					if (contig_nulls >= 2) return utf32;
+					if (contig_nulls >= 2) return streamFormat = utf32;
 
 					contig_nulls++;
 				}
@@ -168,9 +171,18 @@ namespace z
 				}
 			}
 
-			if (found_nulls) return utf16;
+			if (found_nulls) return streamFormat = utf16;
 
-			return can_utf8 ? utf8 : ascii;
+			return streamFormat = (can_utf8 ? utf8 : ascii);
+		}
+
+		void memoryStream::setFormat(encoding enc, bool force)
+		{
+			if (!initialized || force)
+			{
+				streamFormat = enc;
+				initialized = true;
+			}
 		}
 
 		void memoryStream::flush() {}

--- a/z/core/memoryStream.h
+++ b/z/core/memoryStream.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "stream.h"
-#include <iostream>
 
 namespace z
 {
@@ -18,6 +17,8 @@ namespace z
 			uint8_t* data;
 			size_t dataSize;
 			size_t streamIndex;
+			encoding streamFormat;
+			bool initialized;
 
 		public:
 			/**
@@ -34,6 +35,8 @@ namespace z
 				data = (uint8_t*)streamData;
 				dataSize = data ? (sizeof(T)*count) : 0;
 				streamIndex = 0;
+				streamFormat = ascii;
+				initialized = false;
 			}
 
 			/**
@@ -66,6 +69,7 @@ namespace z
  			size_t end();
 
 			encoding format();
+			void setFormat(encoding enc, bool force = false);
 
 			void flush();
 		};

--- a/z/core/stream.h
+++ b/z/core/stream.h
@@ -120,7 +120,9 @@ namespace z
 			 *
 			 * \return The determined encoding format of the stream.
 			 */
-			 virtual encoding format() = 0;
+			virtual encoding format() = 0;
+
+			virtual void setFormat(encoding enc, bool force = false) = 0;
 		};
 
 		/**
@@ -237,6 +239,8 @@ namespace z
 			 * \return The determined encoding format of the stream.
 			 */
 			virtual encoding format() = 0;
+
+			virtual void setFormat(encoding enc, bool force = false) = 0;
 
 			 /**
 			 * \brief Flush all data from the stream buffer.

--- a/z/core/string.h
+++ b/z/core/string.h
@@ -870,9 +870,8 @@ namespace z
 			 *
 			 * \param stream The stream to read from.
 			 * \param delim The delimiter to read until.
-			 * \param enc The encoding of characters on the stream.
 			 */
-			void read(inputStream& stream, uint32_t delim = 0, encoding enc = E);
+			void read(inputStream& stream, uint32_t delim = 0);
 
 			/**
 			 * \brief Read string data from a stream until a newline is encountered.
@@ -882,9 +881,8 @@ namespace z
 			 * Any data this string contains is wiped when this function is called.
 			 *
 			 * \param stream The stream to read from.
-			 * \param enc The encoding of characters on the stream.
 			 */
-			void readln(inputStream& stream, encoding enc = E);
+			void readln(inputStream& stream);
 
 			/**
 			 * \brief Write string data to a stream.

--- a/z/core/string.h
+++ b/z/core/string.h
@@ -41,7 +41,7 @@ namespace z
 			size_t character_ct;
 
 			void initChar(uint32_t, size_t);
-			void increase(size_t); //increase number of data bytes up to the given amount
+			void increase(size_t); //increase number of characters up to the given amount
 			constexpr size_t charSize() const;
 
 			void initInt(long long, unsigned int, unsigned int);

--- a/z/core/string.h
+++ b/z/core/string.h
@@ -890,7 +890,20 @@ namespace z
 			 * \param stream The stream to write to.
 			 * \param enc The encoding of characters on the stream.
 			 */
-			void write(outputStream& stream, encoding enc = E) const;
+			void write(outputStream& stream, encoding enc) const;
+
+			/**
+			 * \brief Write string data to a stream in that stream's encoding.
+			 *
+			 * \param stream The stream to write to.
+			 */
+			void write(outputStream& stream) const
+			{
+				stream.setFormat(E);
+				encoding enc = stream.format();
+
+				write(stream, enc);
+			}
 
 			/**
 			 * \brief Write string data to a stream, appending a newline.
@@ -900,7 +913,22 @@ namespace z
 			 * \param stream The stream to write to.
 			 * \param enc The encoding of characters on the stream.
 			 */
-			void writeln(outputStream& stream, encoding enc = E) const;
+			void writeln(outputStream& stream, encoding enc) const;
+
+			/**
+			 * \brief Write string data to a stream in its format, appending a newline.
+			 *
+			 * Actual characters in the newline depends on operating system (usually `\n`, `\r\n` on Windows).
+			 *
+			 * \param stream The stream to write to.
+			 */
+			void writeln(outputStream& stream) const
+			{
+				stream.setFormat(E);
+				encoding enc = stream.format();
+
+				writeln(stream, enc);
+			}
 		};
 
 	}

--- a/z/core/string/utf8.h
+++ b/z/core/string/utf8.h
@@ -5,8 +5,9 @@ namespace z
 	namespace core
 	{
 		template <>
-		void string<utf8>::increase(size_t goal)
+		void string<utf8>::increase(size_t max_chars)
 		{
+			size_t goal = max_chars + 1; //account for null byte at the end
 			if (data_len >= goal) return;
 
 			uint8_t* old_data = data;
@@ -14,7 +15,7 @@ namespace z
 
 			//~1.5x string growth
 			while (data_len < goal)
-				data_len += (data_len >> 1) + 4;
+				data_len += (data_len + 4) >> 1;
 			data = new uint8_t[data_len];
 
 			size_t remain = old_data_len;
@@ -24,7 +25,7 @@ namespace z
 			size_t i = 0;
 
 			//copy as much data as possible in 32-bit chunks
-			while (remain > 4)
+			while (remain >= 4)
 			{
 				data32[i] = old32[i];
 
@@ -40,6 +41,8 @@ namespace z
 
 				remain--;
 			}
+
+			delete[] old_data;
 		}
 
 		template <>
@@ -1331,10 +1334,10 @@ namespace z
 		}
 
 		template <>
-		void string<utf8>::read(inputStream& stream, uint32_t delim, encoding enc)
+		void string<utf8>::read(inputStream& stream, uint32_t delim)
 		{
 			character_ct = 0;
-			this->increase(1);
+			increase(character_ct);
 
 			if (stream.bad() || stream.empty())
 			{
@@ -1342,6 +1345,7 @@ namespace z
 				return;
 			}
 
+			encoding enc = stream.format();
 			uint32_t last = stream.getChar(enc);
 
 			while (!stream.empty() && (delim ? (last == delim) : isWhiteSpace(last)))
@@ -1351,14 +1355,15 @@ namespace z
 			{
 				if (enc == utf8)
 				{
+					increase(character_ct);
 					data[character_ct++] = last;
-					this->increase(character_ct+1);
 				}
 				else
 				{
 					uint8_t c[4];
 					int len = toUTF8(c, last);
-					this->increase(character_ct + len + 1);
+					increase(character_ct+len);
+
 					for (int i=0; i<len; i++)
 						data[character_ct+i] = c[i];
 
@@ -1368,14 +1373,15 @@ namespace z
 				last = stream.getChar(enc);
 			}
 
+			increase(character_ct);
 			data[character_ct] = 0;
 		}
 
 		template <>
-		void string<utf8>::readln(inputStream& stream, encoding enc)
+		void string<utf8>::readln(inputStream& stream)
 		{
 			character_ct = 0;
-			this->increase(1);
+			increase(character_ct);
 
 			if (stream.bad() || stream.empty())
 			{
@@ -1383,42 +1389,46 @@ namespace z
 				return;
 			}
 
-			uint32_t last = stream.getChar(enc);
+			encoding enc = stream.format();
+			uint32_t last = stream.getChar(utf8);
 
 			while (!stream.empty())
 			{
 				if (last == '\r')
 				{
+					auto pos = stream.tell();
 					last = stream.getChar(enc);
-					if (last == '\n')
+					if (last != '\n')
 					{
-						data[character_ct] = 0;
-						return;
+						stream.seek(pos);
 					}
-					data[character_ct++] = '\r';
-					this->increase(character_ct+1);
-					if (stream.empty())
-					{
-						data[character_ct] = 0;
-						return;
-					}
+
+					data[character_ct] = 0;
+					return;
 				}
 				else if (last == '\n')
 				{
+					auto pos = stream.tell();
+					last = stream.getChar(enc);
+					if (last != '\r')
+					{
+						stream.seek(pos);
+					}
+
 					data[character_ct] = 0;
 					return;
 				}
 
 				if (enc == utf8)
 				{
+					increase(character_ct);
 					data[character_ct++] = last;
-					this->increase(character_ct+1);
 				}
 				else
 				{
 					uint8_t c[4];
 					int len = toUTF8(c, last);
-					this->increase(character_ct + len + 1);
+					increase(character_ct + len);
 					for (int i=0; i<len; i++)
 						data[character_ct+i] = c[i];
 
@@ -1428,6 +1438,7 @@ namespace z
 				last = stream.getChar(enc);
 			}
 
+			increase(character_ct);
 			data[character_ct] = 0;
 		}
 

--- a/z/file/inputStream.cpp
+++ b/z/file/inputStream.cpp
@@ -232,6 +232,12 @@ namespace z
 			return streamFormat = (can_ascii ? ascii : utf8);
 		}
 
+		void inputStream::setFormat(encoding enc, bool force)
+		{
+			format();
+			if (force) streamFormat = enc;
+		}
+
 		size_t inputStream::endianness()
 		{
 			return endianness_;

--- a/z/file/inputStream.cpp
+++ b/z/file/inputStream.cpp
@@ -3,8 +3,6 @@
 
 #define MAX_BYTE_READ 32
 
-#include <iostream>
-
 namespace z
 {
 	namespace file
@@ -153,11 +151,11 @@ namespace z
 				buf[b_i] = get();
 				if (buf[b_i] == BOM[b_i])
 				{
-					endianness_ = __ORDER_BIG_ENDIAN__;
+					endianness_ = __ORDER_LITTLE_ENDIAN__;
 				}
 				else if (buf[b_i] == BOM[4-b_i])
 				{
-					endianness_ = __ORDER_LITTLE_ENDIAN__;
+					endianness_ = __ORDER_BIG_ENDIAN__;
 				}
 				else
 				{
@@ -168,15 +166,18 @@ namespace z
 			if (b_i == 2)
 			{
 				initialized = true;
+				seek(2);
 				return streamFormat = utf16;
 			}
 			else if (b_i == 4)
 			{
 				initialized = true;
+				seek(4);
 				return streamFormat = utf32;
 			}
+			seek(0);
 
-			/*for (size_t i=0; i<read_max; i++)
+			for (size_t i=0; i<read_max; i++)
 			{
 				uint8_t ch = get();
 				if (ch > 127) can_ascii = false;
@@ -224,7 +225,7 @@ namespace z
 					buf[b_i++] = ch;
 				}
 			}
-			*/
+
 			initialized = true;
 			seek(init_pos);
 			if (has_null) return streamFormat = utf16;

--- a/z/file/inputStream.h
+++ b/z/file/inputStream.h
@@ -64,6 +64,7 @@ namespace z
 			size_t end();
 
 			encoding format();
+			void setFormat(encoding enc, bool force = false);
 			size_t endianness();
 		};
 	}

--- a/z/file/inputStream.h
+++ b/z/file/inputStream.h
@@ -21,7 +21,16 @@ namespace z
 		private:
 			std::ifstream filestream;
 
+			size_t endianness;
+			encoding streamFormat;
+			bool initialized;
+
 		public:
+			/**
+			 * \brief Empty constructor.
+			 */
+			inputStream();
+
 			/**
 			 * \brief Constructor
 			 *

--- a/z/file/inputStream.h
+++ b/z/file/inputStream.h
@@ -21,7 +21,7 @@ namespace z
 		private:
 			std::ifstream filestream;
 
-			size_t endianness;
+			size_t endianness_;
 			encoding streamFormat;
 			bool initialized;
 
@@ -64,6 +64,7 @@ namespace z
 			size_t end();
 
 			encoding format();
+			size_t endianness();
 		};
 	}
 }

--- a/z/file/outputStream.cpp
+++ b/z/file/outputStream.cpp
@@ -80,30 +80,26 @@ namespace z
 				{
 					if (endianness_ == __ORDER_BIG_ENDIAN__)
 					{
-						filestream.put(0x00);
-						filestream.put(0x00);
-						filestream.put(0xFE);
-						filestream.put(0xFF);
+						char buf[] = {0,0,(char)254,(char)255};
+						filestream.write(buf,4);
 					}
 					else
 					{
-						filestream.put(0xFF);
-						filestream.put(0xFE);
-						filestream.put(0x00);
-						filestream.put(0x00);
+						char buf[] = {(char)255,(char)254,0,0};
+						filestream.write(buf,4);
 					}
 				}
 				else if (streamFormat == utf16)
 				{
 					if (endianness_ == __ORDER_BIG_ENDIAN__)
 					{
-						filestream.put(0xFE);
-						filestream.put(0xFF);
+						char buf[] = {(char)254,(char)255};
+						filestream.write(buf,2);
 					}
 					else
 					{
-						filestream.put(0xFF);
-						filestream.put(0xFE);
+						char buf[] = {(char)255,(char)254};
+						filestream.write(buf,2);
 					}
 				}
 			}

--- a/z/file/outputStream.cpp
+++ b/z/file/outputStream.cpp
@@ -1,30 +1,69 @@
 #include "outputStream.h"
 #include <z/core/charFunctions.h>
 
+#include "inputStream.h"
+
 namespace z
 {
 	namespace file
 	{
-		outputStream::outputStream(const zpath& fileName, bool append)
+		outputStream::outputStream()
 		{
-			if (append)
-				filestream.open((const char*)fileName.cstring(), std::ios::app | std::ios::out);
-			else
-				filestream.open((const char*)fileName.cstring(), std::ios::out);
+			initialized = false;
 		}
 
-		void outputStream::open(const zpath& fileName, bool append)
+		outputStream::outputStream(const zpath& fileName, encoding fileFormat, bool append)
+		{
+			initialized = true;
+
+			if (append)
+			{
+				inputStream tempStream (fileName);
+				if (tempStream.good())
+				{
+					streamFormat = tempStream.format();
+					endianness_ = tempStream.endianness();
+					tempStream.close();
+
+					filestream.open((const char*)fileName.cstring(), std::ios::app | std::ios::out);
+					return;
+				}
+			}
+
+			endianness_ = __BYTE_ORDER__;
+			streamFormat = fileFormat;
+			filestream.open((const char*)fileName.cstring(), std::ios::out);
+		}
+
+		void outputStream::open(const zpath& fileName, encoding fileFormat, bool append)
 		{
 			filestream.close();
+
+			initialized = true;
+
 			if (append)
-				filestream.open((const char*)fileName.cstring(), std::ios::app | std::ios::out);
-			else
-				filestream.open((const char*)fileName.cstring(), std::ios::out);
+			{
+				inputStream tempStream (fileName);
+				if (tempStream.good())
+				{
+					streamFormat = tempStream.format();
+					endianness_ = tempStream.endianness();
+					tempStream.close();
+
+					filestream.open((const char*)fileName.cstring(), std::ios::app | std::ios::out);
+					return;
+				}
+			}
+
+			endianness_ = __BYTE_ORDER__;
+			streamFormat = fileFormat;
+			filestream.open((const char*)fileName.cstring(), std::ios::out);
 		}
 
 		void outputStream::close()
 		{
 			filestream.close();
+			initialized = false;
 		}
 
 		void outputStream::put(uint8_t ch)
@@ -34,23 +73,116 @@ namespace z
 
 		void outputStream::put(uint8_t* str, size_t count, encoding format)
 		{
-			size_t datact;
-			switch (format)
+			//write the BOM if we're at the beginning of the stream.
+			if (!tell())
 			{
-			case utf16:
-				datact = count << 1;
-				break;
-
-			case utf32:
-				datact = count << 2;
-				break;
-
-			default:
-				datact = count;
+				if (streamFormat == utf32)
+				{
+					if (endianness_ == __ORDER_BIG_ENDIAN__)
+					{
+						filestream.put(0x00);
+						filestream.put(0x00);
+						filestream.put(0xFE);
+						filestream.put(0xFF);
+					}
+					else
+					{
+						filestream.put(0xFF);
+						filestream.put(0xFE);
+						filestream.put(0x00);
+						filestream.put(0x00);
+					}
+				}
+				else if (streamFormat == utf16)
+				{
+					if (endianness_ == __ORDER_BIG_ENDIAN__)
+					{
+						filestream.put(0xFE);
+						filestream.put(0xFF);
+					}
+					else
+					{
+						filestream.put(0xFF);
+						filestream.put(0xFE);
+					}
+				}
 			}
 
-			for (size_t i=0; i<datact; i++)
-				filestream.put(str[i]);
+			for (size_t i=0; i<count; i++)
+			{
+				if (format == utf32)
+				{
+// 					size_t index = i << 2;
+// 					uint32_t ch = *((uint32_t*)&str[index]);
+// 					// uint8_t* buf = (uint8_t*)&ch;
+// 					if (streamFormat == utf16)
+// 					{
+//
+// 					}
+//
+// #					if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+// 					if (endianness_ == __ORDER_LITTLE_ENDIAN__)
+// 					{
+// 						buf[0] = str[index+3];
+// 						buf[1] = str[index+2];
+// 						buf[2] = str[index+1];
+// 						buf[3] = str[index];
+// 					}
+// #					else
+// 					if (endianness_ == __ORDER_BIG_ENDIAN__)
+// 					{
+// 						buf[0] = str[index+3];
+// 						buf[1] = str[index+2];
+// 						buf[2] = str[index+1];
+// 						buf[3] = str[index];
+// 					}
+// #					endif
+// 					else
+// 					{
+// 						buf[0] = str[index];
+// 						buf[1] = str[index+1];
+// 						buf[2] = str[index+2];
+// 						buf[3] = str[index+3];
+// 					}
+//
+// 					if (streamFormat == utf16)
+// 					{
+// 						uint16_t = ch16;
+// 						buf = (uint16_t*)&ch16;
+// 						if (ch > 0xFFFF)
+// 						{
+//
+// 						}
+// 					}
+				}
+				else if (format == utf16)
+				{
+					size_t index = i << 1;
+
+#					if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+					if (endianness_ == __ORDER_LITTLE_ENDIAN__)
+					{
+						filestream.put(str[index+1]);
+						filestream.put(str[index]);
+					}
+#					else
+					if (endianness_ == __ORDER_BIG_ENDIAN__)
+					{
+						filestream.put(str[index+1]);
+						filestream.put(str[index]);
+					}
+#					endif
+					else
+					{
+						filestream.put(str[index]);
+						filestream.put(str[index+1]);
+					}
+				}
+				else
+				{
+					filestream.put(str[i]);
+				}
+			}
 		}
 
 		void outputStream::seek(size_t index)
@@ -95,12 +227,17 @@ namespace z
 
 		encoding outputStream::format()
 		{
-			return ascii;
+			return streamFormat;
 		}
 
 		void outputStream::flush()
 		{
 			filestream.flush();
+		}
+
+		size_t outputStream::endianness()
+		{
+			return endianness_;
 		}
 	}
 }

--- a/z/file/outputStream.cpp
+++ b/z/file/outputStream.cpp
@@ -104,79 +104,44 @@ namespace z
 				}
 			}
 
-			for (size_t i=0; i<count; i++)
-			{
-				if (format == utf32)
-				{
-// 					size_t index = i << 2;
-// 					uint32_t ch = *((uint32_t*)&str[index]);
-// 					// uint8_t* buf = (uint8_t*)&ch;
-// 					if (streamFormat == utf16)
-// 					{
-//
-// 					}
-//
-// #					if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-// 					if (endianness_ == __ORDER_LITTLE_ENDIAN__)
-// 					{
-// 						buf[0] = str[index+3];
-// 						buf[1] = str[index+2];
-// 						buf[2] = str[index+1];
-// 						buf[3] = str[index];
-// 					}
-// #					else
-// 					if (endianness_ == __ORDER_BIG_ENDIAN__)
-// 					{
-// 						buf[0] = str[index+3];
-// 						buf[1] = str[index+2];
-// 						buf[2] = str[index+1];
-// 						buf[3] = str[index];
-// 					}
-// #					endif
-// 					else
-// 					{
-// 						buf[0] = str[index];
-// 						buf[1] = str[index+1];
-// 						buf[2] = str[index+2];
-// 						buf[3] = str[index+3];
-// 					}
-//
-// 					if (streamFormat == utf16)
-// 					{
-// 						uint16_t = ch16;
-// 						buf = (uint16_t*)&ch16;
-// 						if (ch > 0xFFFF)
-// 						{
-//
-// 						}
-// 					}
-				}
-				else if (format == utf16)
-				{
-					size_t index = i << 1;
 
-#					if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-					if (endianness_ == __ORDER_LITTLE_ENDIAN__)
-					{
-						filestream.put(str[index+1]);
-						filestream.put(str[index]);
-					}
-#					else
-					if (endianness_ == __ORDER_BIG_ENDIAN__)
-					{
-						filestream.put(str[index+1]);
-						filestream.put(str[index]);
-					}
-#					endif
-					else
-					{
-						filestream.put(str[index]);
-						filestream.put(str[index+1]);
-					}
+			if ((format == utf8) || (format == ascii))
+			{
+				filestream.write((char*)str, count);
+			}
+			else
+			{
+				if (endianness_ == __BYTE_ORDER__)
+				{
+					if (format == utf32)
+						filestream.write((char*)str, count << 2);
+					else //(format == utf16)
+						filestream.write((char*)str, count << 1);
 				}
 				else
 				{
-					filestream.put(str[i]);
+					char buf[4];
+					size_t index;
+
+					for (size_t i=0; i<count; i++)
+					{
+						if (format == utf32)
+						{
+							index = i << 2;
+							buf[0] = str[index+3];
+							buf[1] = str[index+2];
+							buf[2] = str[index+1];
+							buf[3] = str[index];
+							filestream.write(buf,4);
+						}
+						else //(format == utf16)
+						{
+							index = i << 1;
+							buf[0] = str[index+1];
+							buf[1] = str[index];
+							filestream.write(buf,2);
+						}
+					}
 				}
 			}
 		}
@@ -224,6 +189,11 @@ namespace z
 		encoding outputStream::format()
 		{
 			return streamFormat;
+		}
+
+		void outputStream::setFormat(encoding enc, bool force)
+		{
+			if (force || !tell()) streamFormat = enc;
 		}
 
 		void outputStream::flush()

--- a/z/file/outputStream.h
+++ b/z/file/outputStream.h
@@ -21,24 +21,33 @@ namespace z
 		private:
 			std::ofstream filestream;
 
+			size_t endianness_;
+			encoding streamFormat;
+
+			bool initialized;
+
 		public:
+			outputStream();
+
 			/**
 			 * \brief Constructor
 			 *
 			 * As this is a file stream, it must be constructed with a file name.
 			 *
 			 * \param fileName a string containing the name of the file to read from.
+			 * \param fileFormat the format to write to the file. If append is set and the file exists, then this parameter is ignored in favor of the file's original encoding.
 			 * \param append set to \b true to append to the file, \b false to overwrite.
 			 */
-			outputStream(const zpath&, bool append = false);
+			outputStream(const zpath&, encoding fileFormat, bool append = false);
 
 			/**
 			 * \brief Reopen the stream to the given file.
 			 *
 			 * \param fileName a string containing the name of the file to read from.
+			 * \param fileFormat the format to write to the file. If append is set, then this parameter is ignored if the file already exists.
 			 * \param append set to \b true to append to the file, \b false to overwrite.
 			 */
-			void open(const zpath& fileName, bool append = false);
+			void open(const zpath& fileName, encoding fileFormat, bool append = false);
 
 			///Close the current file stream.
 			void close();
@@ -70,6 +79,8 @@ namespace z
 			encoding format();
 
 			void flush();
+
+			size_t endianness();
 		};
 	}
 }

--- a/z/file/outputStream.h
+++ b/z/file/outputStream.h
@@ -78,6 +78,8 @@ namespace z
 			 */
 			encoding format();
 
+			void setFormat(encoding enc, bool force = false);
+
 			void flush();
 
 			size_t endianness();

--- a/z/system/console.cpp
+++ b/z/system/console.cpp
@@ -110,6 +110,12 @@ namespace z
 			return utf8;
 		}
 
+		void console::setFormat(encoding enc, bool force)
+		{
+			(void)enc;
+			(void)force;
+		}
+
 		void console::flush()
 		{
 			std::cout << std::flush;

--- a/z/system/console.h
+++ b/z/system/console.h
@@ -51,6 +51,8 @@ namespace z
 			 */
 			encoding format();
 
+			void setFormat(encoding enc, bool force = false);
+
 			void flush();
  		};
 	}

--- a/z/util/dictionary.cpp
+++ b/z/util/dictionary.cpp
@@ -37,12 +37,12 @@ namespace z
 
 			core::string<Z_DICT_FORMAT> name;
 
-			name.read(stream, 0, streamFormat);
+			name.read(stream);
 			while (!(stream.empty() || time.timedOut()))
 			{
 				wordList.add(new word(name));
 
-				name.read(stream, 0, streamFormat);
+				name.read(stream);
 			}
 
 			return stream.empty();


### PR DESCRIPTION
Streams can now implicitly convert encoding to/from strings, and file streams also automatically convert to native endianness.