### PR TITLE
Add code coverage reporting

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -14,11 +14,13 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install Dependencies
-      run: sudo apt-get install -y --no-install-recommends doxygen graphviz
+      run: sudo apt-get install -y --no-install-recommends doxygen graphviz python3
+    - name: Fetch Repo
+      run: git fetch --unshallow
+    - name: Generate Code Coverage Page
+      run: make coverage -j32
     - name: Build Documentation
-      run: |
-        git fetch --unshallow
-        make docs
+      run: make docs
     - name: Deploy Documentation
       uses: peaceiris/actions-gh-pages@v3.9.3
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ examples/obj
 *.gcov
 *.d
 Doxypages/examples.dox
+venv/
+coverage.txt
+coverage.html

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ Doxypages/examples.dox
 venv/
 coverage.txt
 coverage.html
+coverage.svg

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![build-linux](https://github.com/ZacharyWesterman/libzed/actions/workflows/build-linux.yml/badge.svg)
 ![build-windows](https://github.com/ZacharyWesterman/libzed/actions/workflows/build-windows.yml/badge.svg)
 ![tests](https://github.com/ZacharyWesterman/libzed/actions/workflows/tests.yml/badge.svg)
+![coverage](https://zacharywesterman.github.io/libzed/coverage.svg)
 
 This library contains useful classes and functions for quick and simple data manipulation.
 The idea is that this will not only take the grunt work out of C++, but it will help decrease
@@ -235,6 +236,8 @@ $ gzexe example.out && rm example.out~
 [Documentation is here][docs] |
 [Look here if you want to contribute](CONTRIBUTING.md)
 
+I use [Catch2](https://github.com/catchorg/Catch2) for unit testing. Full test coverage is still ongoing, but you can see the [current coverage report here][coverage].
+
 [docs]: https://zacharywesterman.github.io/libzed
 [repo]: https://github.com/ZacharyWesterman/libzed
 [strings]: https://zacharywesterman.github.io/libzed/classz_1_1core_1_1string.html
@@ -244,3 +247,4 @@ $ gzexe example.out && rm example.out~
 [examples]: https://zacharywesterman.github.io/libzed/examples.html
 [generators]: https://zacharywesterman.github.io/libzed/classz_1_1core_1_1generator.html
 [memoization]: https://zacharywesterman.github.io/libzed/classz_1_1core_1_1memoize.html
+[coverage]: https://zacharywesterman.github.io/libzed/coverage.html

--- a/makefile
+++ b/makefile
@@ -183,6 +183,9 @@ benchmarks: static
 	$(MAKE) -C benchmarks/ STD=$(STD)
 	./benchmarks/bin/run_benchmarks "$(FILTER)"
 
+coverage: tests
+	make -C tests coverage
+
 $(SHARED_LIB): $(OBJS)
 	$(LN) -o $@ $^ $(LFLAGS)
 
@@ -253,4 +256,4 @@ get-version:
 get-revision:
 	git rev-parse HEAD
 
-.PHONY: rebuild clean cleanobjs cleanbin cleancov cleandox default install uninstall examples static dynamic shared all lint test tests benchmark benchmarks docs dox format try-format count-loc get-version get-revision
+.PHONY: rebuild clean cleanobjs cleanbin cleancov cleandox default install uninstall examples static dynamic shared all lint test tests benchmark benchmarks docs dox format try-format count-loc get-version get-revision coverage

--- a/makefile
+++ b/makefile
@@ -183,6 +183,8 @@ benchmarks: static
 	$(MAKE) -C benchmarks/ STD=$(STD)
 	./benchmarks/bin/run_benchmarks "$(FILTER)"
 
+coverage-html: tests
+	make -C tests coverage.html
 coverage: tests
 	make -C tests coverage
 
@@ -243,6 +245,7 @@ docs: html
 html: $(HEADERS) Doxyfile $(wildcard Doxypages/*.dox) Doxypages/examples.dox $(wildcard examples/src/*.cpp) README.md
 	$(RMDIR) html
 	PROJECT_NUMBER=$(VER_MAJOR).$(VER_MINOR).$(VER_PATCH) doxygen
+	cp tests/coverage.html html/ 2>/dev/null || :
 
 Doxypages/examples.dox: examples/src/*.cpp
 	@{ echo '/**'; for file in $^; do echo "@example $$(basename $$file)"; done; echo '*/'; } > $@
@@ -256,4 +259,4 @@ get-version:
 get-revision:
 	git rev-parse HEAD
 
-.PHONY: rebuild clean cleanobjs cleanbin cleancov cleandox default install uninstall examples static dynamic shared all lint test tests benchmark benchmarks docs dox format try-format count-loc get-version get-revision coverage
+.PHONY: rebuild clean cleanobjs cleanbin cleancov cleandox default install uninstall examples static dynamic shared all lint test tests benchmark benchmarks docs dox format try-format count-loc get-version get-revision coverage coverage-html

--- a/tests/makefile
+++ b/tests/makefile
@@ -7,10 +7,11 @@ LFLAGS = --coverage
 
 SRCS = $(wildcard $(addsuffix *.cpp, src/))
 OBJS = $(patsubst %.cpp,%.o,$(SRCS)) src/catch/catch_amalgamated.o
+COVS := $(patsubst %,%.gcov,$(SRCS))
 
-all: bin/libtest.so bin/run_tests
+all: bin/run_tests
 
-bin/run_tests: $(OBJS) ../libzed.a
+bin/run_tests: $(OBJS) ../libzed.a bin/libtest.so
 	$(LN) -o $@ $^ $(LFLAGS)
 
 %.o: %.cpp
@@ -20,6 +21,37 @@ bin/%.so: data/%.cpp
 	$(CC) -I"../" -std=$(STD) -shared -fPIC -Wl,--gc-sections -o $@ $^
 
 clean:
-	rm -f bin/* src/*.o src/*.gcda src/*.gcno *.gcov data/*.so src/catch/*.o src/catch/*.gcda src/catch/*.gcno
+	rm -f bin/* src/*.o src/*.gcda src/*.gcno *.gcov data/*.so src/catch/*.o src/catch/*.gcda src/catch/*.gcno src/*.gcov coverage.*
 
-.PHONY: all clean
+pristine: clean
+	rm -rf venv
+
+coverage: coverage.txt
+coverage.txt: $(COVS) venv/bin/gcovr
+	( \
+		. venv/bin/activate; \
+		gcovr -r .. src --exclude src/catch --exclude src --txt $@ \
+	)
+coverage.html: $(COVS) venv/bin/gcovr
+	( \
+		. venv/bin/activate; \
+		gcovr -r .. src --exclude src/catch --exclude src --html $@ \
+	)
+
+%.gcov: % makefile src/array.gcda
+	gcov $< -t >$@
+
+src/array.gcda: bin/run_tests
+	bin/run_tests
+
+venv/bin/gcovr: venv/bin/activate
+	( \
+		. venv/bin/activate; \
+		python3 -m pip install gcovr \
+	)
+
+venv/bin/activate:
+	python3 -m venv venv
+
+
+.PHONY: all clean coverage pristine

--- a/tests/makefile
+++ b/tests/makefile
@@ -27,18 +27,25 @@ pristine: clean
 	rm -rf venv
 
 coverage: coverage.txt
+
+coverage.svg: coverage.txt
+coverage.html: coverage.txt
 coverage.txt: $(COVS) venv/bin/gcovr
 	( \
 		. venv/bin/activate; \
-		gcovr -r .. src --exclude src/catch --exclude src --txt $@ \
+		gcovr -r .. src --exclude src/catch --exclude src --txt $@ --html coverage.html \
 	)
-coverage.html: $(COVS) venv/bin/gcovr
 	( \
-		. venv/bin/activate; \
-		gcovr -r .. src --exclude src/catch --exclude src --html $@ \
+		percent="$$(grep TOTAL coverage.txt | awk '{print $$4}')"; \
+		percent="$${percent%?}"; \
+		color=red; \
+		[ "$$percent" -ge 60 ] && color=orange \
+		[ "$$percent" -ge 75 ] && color=yellow; \
+		[ "$$percent" -ge 90 ] && color=green; \
+		wget "https://img.shields.io/badge/Coverage-$$percent%25-$$color" -O coverage.svg; \
 	)
 
-%.gcov: % makefile src/array.gcda
+%.gcov: % src/array.gcda
 	gcov $< -t >$@
 
 src/array.gcda: bin/run_tests

--- a/tests/src/array.cpp
+++ b/tests/src/array.cpp
@@ -1,4 +1,4 @@
-#include "../../z/core/array.hpp"
+#include "../../z/all.hpp"
 #include "catch/catch_amalgamated.hpp"
 
 using z::core::array;

--- a/tests/src/file.cpp
+++ b/tests/src/file.cpp
@@ -1,4 +1,4 @@
-#include "../../z/file.hpp"
+#include "../../z/all.hpp"
 #include "catch/catch_amalgamated.hpp"
 
 TEST_CASE("Validate basename", "[file]") {

--- a/tests/src/generator.cpp
+++ b/tests/src/generator.cpp
@@ -4,8 +4,7 @@
 // However, generators do not have all the functions that arrays do;
 // They are meant to be iterated over once, and then discarded.
 
-#include "../../z/core/join.hpp"
-#include "../../z/core/range.hpp"
+#include "../../z/all.hpp"
 #include "catch/catch_amalgamated.hpp"
 #include <iostream>
 

--- a/tests/src/generic.cpp
+++ b/tests/src/generic.cpp
@@ -1,5 +1,4 @@
-#include "../../z/util/generic.hpp"
-#include "../../z/util/exceptions.hpp"
+#include "../../z/all.hpp"
 #include "catch/catch_amalgamated.hpp"
 
 // Only run these tests if std::variant is available.

--- a/tests/src/hash32.cpp
+++ b/tests/src/hash32.cpp
@@ -1,5 +1,4 @@
-#include "../../z/core/hash32.hpp"
-#include "../../z/core/string.hpp"
+#include "../../z/all.hpp"
 #include "catch/catch_amalgamated.hpp"
 
 TEST_CASE("Compile-time CRC32 hash", "[hash32]") {

--- a/tests/src/math.cpp
+++ b/tests/src/math.cpp
@@ -1,6 +1,6 @@
 #include "catch/catch_amalgamated.hpp"
 
-#include "../../z/math.hpp"
+#include "../../z/all.hpp"
 
 using z::math::levenschtein;
 

--- a/tests/src/memoize.cpp
+++ b/tests/src/memoize.cpp
@@ -1,4 +1,4 @@
-#include "../../z/core/memoize.hpp"
+#include "../../z/all.hpp"
 #include "catch/catch_amalgamated.hpp"
 
 using z::core::memoize;

--- a/tests/src/range.cpp
+++ b/tests/src/range.cpp
@@ -1,4 +1,4 @@
-#include "../../z/core/range.hpp"
+#include "../../z/all.hpp"
 #include "catch/catch_amalgamated.hpp"
 
 TEST_CASE("Range, forward iteration", "[range]") {

--- a/tests/src/strings.cpp
+++ b/tests/src/strings.cpp
@@ -1,4 +1,4 @@
-#include "../../z/core.hpp"
+#include "../../z/all.hpp"
 #include "catch/catch_amalgamated.hpp"
 
 #define STRTEST(a) \

--- a/z/file.hpp
+++ b/z/file.hpp
@@ -29,3 +29,6 @@
 
 /// Dynamic library loading
 #include "file/library.hpp"
+
+/// Exceptions
+#include "file/exceptions.hpp"

--- a/z/util.hpp
+++ b/z/util.hpp
@@ -11,3 +11,6 @@
 #include "util/dictionary.hpp"
 #include "util/generic.hpp"
 #include "util/progress.hpp"
+
+/// Exceptions
+#include "util/exceptions.hpp"


### PR DESCRIPTION
When documentation is deployed, code coverage is calculated and report is saved to docs (accessible via readme).
Also, a badge has been added to the readme to see coverage at a glance.